### PR TITLE
Added Friends, UserInfo, and other small fixes

### DIFF
--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Authentication/Authentication.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Authentication/Authentication.cpp
@@ -131,13 +131,6 @@ void UEOSAuthentication::LoginCompleteCallback( const EOS_Auth_LoginCallbackInfo
 	{
 		UEOSManager::GetAuthentication()->AccountId = Data->LocalUserId;
 
-		EOS_Auth_Token* UserAuthToken;
-		if( EOS_Auth_CopyUserAuthToken( AuthHandle, UEOSManager::GetAuthentication()->AccountId, &UserAuthToken ) == EOS_EResult::EOS_Success )
-		{
-			PrintAuthToken( UserAuthToken );
-			EOS_Auth_Token_Release( UserAuthToken );
-		}
-
 		const int32_t AccountsCount = EOS_Auth_GetLoggedInAccountsCount( AuthHandle );
 		for( int32_t AccountIdx = 0; AccountIdx < AccountsCount; ++AccountIdx )
 		{

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Authentication/Authentication.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Authentication/Authentication.cpp
@@ -98,6 +98,17 @@ bool UEOSAuthentication::GetAuthorised()
 	return bAuthorised;
 }
 
+bool UEOSAuthentication::GetAuthTokenCopy(EOS_Auth_Token** OutToken)
+{
+	EOS_EResult Result = EOS_Auth_CopyUserAuthToken(AuthHandle, UEOSManager::GetAuthentication()->AccountId, OutToken);
+	return Result == EOS_EResult::EOS_Success;
+}
+
+void UEOSAuthentication::ReleaseAuthToken(EOS_Auth_Token* Token)
+{
+	EOS_Auth_Token_Release( Token );
+}
+
 FString UEOSAuthentication::AccountIDToString( EOS_AccountId InAccountId )
 {
 	static char TempBuffer[EOS_ACCOUNTID_MAX_LENGTH];
@@ -204,9 +215,6 @@ void UEOSAuthentication::PrintAuthToken( EOS_Auth_Token* InAuthToken )
 	UE_LOG( UEOSLog, Warning, TEXT( "%s" ), *MessageText );
 	MessageText = FString::Printf( TEXT( "[EOS SDK | Plugin] - AccountId: %s" ), InAuthToken->AccountId );
 	UE_LOG( UEOSLog, Warning, TEXT( "%s" ), *MessageText );
-
-	MessageText = FString::Printf( TEXT( "[EOS SDK | Plugin] - AccessToken: %s" ), InAuthToken->AccessToken );
-	UE_LOG( UEOSLog, Warning, TEXT( "%s" ), *MessageText );
 	MessageText = FString::Printf( TEXT( "[EOS SDK | Plugin] - AccessToken: %s" ), InAuthToken->AccessToken );
 	UE_LOG( UEOSLog, Warning, TEXT( "%s" ), *MessageText );
 	MessageText = FString::Printf( TEXT( "[EOS SDK | Plugin] - ExpiresIn: %0.2f" ), InAuthToken->ExpiresIn );
@@ -222,6 +230,12 @@ FString FAccountId::ToString() const
 	EOS_AccountId_ToString( AccountId, TempBuffer, &TempBufferSize );
 	FString returnValue( TempBuffer );
 	return returnValue;
+}
+
+FAccountId FAccountId::FromString(const FString& AccountId)
+{
+	EOS_AccountId Account = EOS_AccountId_FromString(TCHAR_TO_ANSI(*AccountId));
+	return FAccountId(Account);
 }
 
 FAccountId::operator bool() const

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Friends/Friends.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Friends/Friends.cpp
@@ -1,0 +1,72 @@
+#include "Friends.h"
+
+#include "UEOSModule.h"
+#include "UEOSManager.h"
+
+UEOSFriends::UEOSFriends()
+	: FriendsHandle(NULL)
+{
+
+}
+
+void UEOSFriends::Init()
+{
+	FriendsHandle = EOS_Platform_GetFriendsInterface(UEOSManager::GetPlatformHandle());
+}
+
+void UEOSFriends::RefreshFriends()
+{
+	EOS_Friends_QueryFriendsOptions Options;
+	Options.ApiVersion = EOS_FRIENDS_QUERYFRIENDS_API_LATEST;
+	Options.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
+	EOS_Friends_QueryFriends(FriendsHandle, &Options, nullptr, QueryFriendsCallback);
+}
+
+void UEOSFriends::QueryFriendsCallback(const EOS_Friends_QueryFriendsCallbackInfo* Data)
+{
+	check(Data != nullptr);
+
+	UEOSFriends* EOSFriends = UEOSManager::GetFriends();
+	if (EOSFriends != nullptr)
+	{
+		if (Data->ResultCode == EOS_EResult::EOS_Success)
+		{
+			EOSFriends->OnFriendsRefreshed.Broadcast();
+		}
+		else
+		{
+			UE_LOG(UEOSLog, Warning, TEXT("[EOS SDK | Plugin] Error when querying friends: %s"),
+						 *UEOSManager::EOSResultToString(Data->ResultCode));
+			EOSFriends->OnRefreshFriendsError.Broadcast();
+		}
+	}
+}
+
+int UEOSFriends::GetFriendsCount()
+{
+	EOS_Friends_GetFriendsCountOptions Options;
+	Options.ApiVersion = EOS_FRIENDS_GETFRIENDSCOUNT_API_LATEST;
+	Options.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
+	return EOS_Friends_GetFriendsCount(FriendsHandle, &Options);
+}
+
+FAccountId UEOSFriends::GetAccountId(int Index)
+{
+	EOS_Friends_GetFriendAtIndexOptions Options;
+	Options.ApiVersion = EOS_FRIENDS_GETFRIENDATINDEX_API_LATEST;
+	Options.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
+	Options.Index = Index;
+	EOS_AccountId AccountId = EOS_Friends_GetFriendAtIndex(FriendsHandle, &Options);
+	return AccountId;
+}
+
+EFriendStatus UEOSFriends::GetStatus(FAccountId AccountId)
+{
+	EOS_Friends_GetStatusOptions StatusOptions;
+	StatusOptions.ApiVersion = EOS_FRIENDS_GETSTATUS_API_LATEST;
+	StatusOptions.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
+	StatusOptions.TargetUserId = AccountId;
+	EOS_EFriendsStatus Status = EOS_Friends_GetStatus(FriendsHandle, &StatusOptions);
+	return (EFriendStatus)Status;
+}
+

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/UEOSManager.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/UEOSManager.cpp
@@ -18,6 +18,8 @@ UEOSManager::UEOSManager()
 	, bEOSShutdown( false )
 	, Authentication( nullptr )
 	, Metrics( nullptr )
+	, Friends( nullptr )
+	, UserInfo( nullptr )
 {
 	
 }
@@ -302,6 +304,40 @@ UEOSMetrics* UEOSManager::GetMetrics()
 	}
 
 	return UEOSManager::EOSManager->Metrics;
+}
+
+UEOSFriends* UEOSManager::GetFriends()
+{
+	if( UEOSManager::EOSManager->Friends == nullptr )
+	{
+		UEOSManager::EOSManager->Friends = NewObject<UEOSFriends>( UEOSManager::EOSManager );
+	}
+
+	if( UEOSManager::EOSManager->Friends == nullptr )
+	{
+		// Failed to instantiate the Friends object.
+		FString MessageText = FString::Printf( TEXT( "[EOS SDK | Plugin] Failed to create Friends Object." ) );
+		UE_LOG( UEOSLog, Warning, TEXT( "%s" ), *MessageText );
+	}
+
+	return UEOSManager::EOSManager->Friends;
+}
+
+UEOSUserInfo* UEOSManager::GetUserInfo()
+{
+	if( UEOSManager::EOSManager->UserInfo == nullptr )
+	{
+		UEOSManager::EOSManager->UserInfo = NewObject<UEOSUserInfo>( UEOSManager::EOSManager );
+	}
+
+	if( UEOSManager::EOSManager->UserInfo == nullptr )
+	{
+		// Failed to instantiate the UserInfo object.
+		FString MessageText = FString::Printf( TEXT( "[EOS SDK | Plugin] Failed to create UserInfo Object." ) );
+		UE_LOG( UEOSLog, Warning, TEXT( "%s" ), *MessageText );
+	}
+
+	return UEOSManager::EOSManager->UserInfo;
 }
 
 FString UEOSManager::EOSResultToString( EOS_EResult Result )

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/UEOSModule.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/UEOSModule.cpp
@@ -127,6 +127,15 @@ void FUEOSModule::UnregisterSettings()
 	
 }
 
+void FUEOSModule::Tick(float DeltaTime)
+{
+	UEOSManager* EOSManager = UEOSManager::GetEOSManager();
+	if (EOSManager != nullptr)
+	{
+		EOSManager->UpdateEOS();
+	}
+}
+
 #undef LOCTEXT_NAMESPACE
 	
 IMPLEMENT_MODULE( FUEOSModule, UEOS )

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/UserInfo/UserInfo.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/UserInfo/UserInfo.cpp
@@ -1,0 +1,78 @@
+#include "UserInfo.h"
+
+#include "UEOSModule.h"
+#include "UEOSManager.h"
+
+UEOSUserInfo::UEOSUserInfo()
+	: UserInfoHandle(NULL)
+{
+
+}
+
+void UEOSUserInfo::Init()
+{
+	UserInfoHandle = EOS_Platform_GetUserInfoInterface(UEOSManager::GetPlatformHandle());
+}
+
+void UEOSUserInfo::QueryNameByAccountId(const FAccountId& AccountId)
+{
+	EOS_UserInfo_QueryUserInfoOptions Options;
+	Options.ApiVersion = EOS_USERINFO_QUERYUSERINFO_API_LATEST;
+	Options.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
+	Options.TargetUserId = AccountId;
+
+	EOS_UserInfo_QueryUserInfo(UserInfoHandle, &Options, nullptr, QueryUserInfoCallback);
+}
+
+FString UEOSUserInfo::GetDisplayName(const FAccountId& AccountId)
+{
+	EOS_UserInfo_CopyUserInfoOptions Options;
+	Options.ApiVersion = EOS_USERINFO_COPYUSERINFO_API_LATEST;
+	Options.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
+	Options.TargetUserId = AccountId;
+
+	EOS_UserInfo* UserInfo = nullptr;
+
+	EOS_EResult ResultCode = EOS_UserInfo_CopyUserInfo(UserInfoHandle, &Options, &UserInfo);
+
+	if (ResultCode != EOS_EResult::EOS_Success)
+	{
+		UE_LOG(UEOSLog, Warning, TEXT("[EOS SDK | Plugin] Error when getting display name: %s"),
+					 *UEOSManager::EOSResultToString(ResultCode));
+	}
+
+	if (UserInfo == nullptr)
+	{
+		return FString();
+	}
+
+	FString Result = FString(UTF8_TO_TCHAR(UserInfo->DisplayName));
+
+	EOS_UserInfo_Release(UserInfo);
+
+	return Result;
+}
+
+void UEOSUserInfo::QueryUserInfoCallback(const EOS_UserInfo_QueryUserInfoCallbackInfo* Data)
+{
+	check(Data != nullptr);
+
+	UEOSUserInfo* EOSUserInfo = UEOSManager::GetUserInfo();
+
+	if (Data->ResultCode == EOS_EResult::EOS_Success)
+	{
+		if (EOSUserInfo != nullptr)
+		{
+			EOSUserInfo->OnUserInfoRetreived.Broadcast(FAccountId(Data->TargetUserId));
+		}
+	}
+	else
+	{
+		UE_LOG(UEOSLog, Warning, TEXT("[EOS SDK | Plugin] Error when querying user info: %s"),
+					 *UEOSManager::EOSResultToString(Data->ResultCode));
+		if (EOSUserInfo != nullptr)
+		{
+			EOSUserInfo->OnUserInfoError.Broadcast(FAccountId(Data->TargetUserId));
+		}
+	}
+}

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Public/Authentication/Authentication.h
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Public/Authentication/Authentication.h
@@ -32,8 +32,11 @@ enum class ELoginMode : uint8
 /**
 * Adapted from the sample, to work within UE4 UBT.
 */
-struct FAccountId
+USTRUCT()
+struct UEOS_API FAccountId
 {
+	GENERATED_BODY()
+
 	/**
 	* Construct wrapper from account id.
 	*/
@@ -75,6 +78,8 @@ struct FAccountId
 	* Prints out account ID as hex.
 	*/
 	FString			ToString() const;
+
+	static FAccountId FromString(const FString& AccountId);
 
 	/** The EOS SDK matching Account Id. */
 	EOS_AccountId	AccountId;
@@ -121,6 +126,18 @@ public:
 		bool						GetAuthorised();
 
 	/**
+	* Creates an auth token for use elsewhere (for example, on a server).
+	* Returns true on succcess, false on failure.
+	* Must be cleaned up by calling ReleaseAuthToken when you're done with it.
+	*/
+	bool GetAuthTokenCopy(EOS_Auth_Token** OutToken);
+
+	/**
+	* Cleans up memory that had been allocated in GetAuthTokenCopy
+	*/
+	void ReleaseAuthToken(EOS_Auth_Token* Token);
+
+	/**
 	* Utility to convert account id to a string
 	*
 	* @param InAccountId - Account id to convert
@@ -151,6 +168,12 @@ public:
 	*/
 	UPROPERTY( BlueprintAssignable, Category = "UEOS|Authentication" )
 		FOnUserLoginFail			OnUserLoginFail;
+
+	UFUNCTION()
+	FAccountId GetAccountId() const
+	{
+		return AccountId;
+	}
 
 protected:
 

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Public/Friends/Friends.h
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Public/Friends/Friends.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include "Object.h"
+
+#include "Authentication.h"
+#include "eos_sdk.h"
+#include "eos_friends.h"
+
+#include "Friends.generated.h"
+
+/** The current status of a friendship.  EOS_EFriendsStatus as a UENUM. */
+UENUM(BlueprintType)
+enum class EFriendStatus : uint8
+{
+	NotFriends = 0,
+	InviteSent = 1,
+	InviteReceived = 2,
+	Friends = 3,
+};
+
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE( FOnFriendsRefreshed );
+
+UCLASS()
+class UEOS_API UEOSFriends : public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+	UEOSFriends();
+	void Init();
+	/**
+	 * Begins an async process that requests the friends count, account ids, and statuses of the local player's friends.
+	 * Broadcasts OnFriendsRefreshed when completed.
+	 */
+	void RefreshFriends();
+	int GetFriendsCount();
+	FAccountId GetAccountId(int Index);
+	EFriendStatus GetStatus(FAccountId AccountId);
+
+	/**
+	 * Fires when a call to RefreshFriends succeeds
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "UEOS|Friends")
+		FOnFriendsRefreshed OnFriendsRefreshed;
+
+	/**
+	 * Fires when a call to RefreshFriends errors
+	 */
+	UPROPERTY(BlueprintAssignable, Category = "UEOS|Friends")
+		FOnFriendsRefreshed OnRefreshFriendsError;
+
+private:
+	static void QueryFriendsCallback(const EOS_Friends_QueryFriendsCallbackInfo* Data);
+
+	/** Handle for the Friends interface. */
+	EOS_HFriends FriendsHandle;
+};
+

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Public/UEOSManager.h
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Public/UEOSManager.h
@@ -10,6 +10,8 @@
 // Forward Declarations
 class UEOSAuthentication;
 class UEOSMetrics;
+class UEOSFriends;
+class UEOSUserInfo;
 
 
 UCLASS()
@@ -80,6 +82,22 @@ public:
 		static UEOSMetrics*						GetMetrics();
 
 	/**
+	 * Attempts to return the current Friends object.
+	 *
+	 * @return UEOSFriends* The current Friends object, or nullptr if not valid.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "UEOS|Manager")
+		static UEOSFriends* GetFriends();
+
+	/**
+	 * Attempts to return the current UserInfo object.
+	 *
+	 * @return UEOSUserInfo* The current UserInfo object, or nullptr if not valid.
+	 */
+	UFUNCTION(BlueprintCallable, Category = "UEOS|Manager")
+		static UEOSUserInfo* GetUserInfo();
+
+	/**
 	* Utility to return an EOS Result as a FString.
 	*
 	* @param Result The EOS Result to attempt to convert.
@@ -137,8 +155,6 @@ public:
 	UFUNCTION( BlueprintPure, Category = "UEOS", meta = ( Keywords = "Get Client Secret" ) )
 		static FString							GetClientSecret();
 
-protected:
-
 	UFUNCTION( BlueprintCallable, Category = "UEOS|Manager" )
 		EEOSResults								InitEOS();
 
@@ -147,6 +163,8 @@ protected:
 
 	UFUNCTION( BlueprintCallable, Category = "UEOS|Manager" )
 		bool									UpdateEOS();
+
+protected:
 
 	// --------------------------------------------------------------
 	// STATIC PROPERTIES
@@ -178,6 +196,14 @@ protected:
 	/** The current Metric object. */
 	UPROPERTY()
 		UEOSMetrics*							Metrics;
+
+	/** The current Friends object. */
+	UPROPERTY()
+		UEOSFriends* Friends;
+
+	/** The current UserInfo object. */
+	UPROPERTY()
+		UEOSUserInfo* UserInfo;
 
 private:
 

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Public/UEOSModule.h
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Public/UEOSModule.h
@@ -3,8 +3,9 @@
 #pragma once
 
 #include "ModuleManager.h"
+#include "Tickable.h"
 
-class FUEOSModule : public IModuleInterface
+class FUEOSModule : public IModuleInterface, public FTickableGameObject
 {
 public:
 
@@ -12,6 +13,16 @@ public:
 	virtual void StartupModule() override;
 	virtual void ShutdownModule() override;
 	virtual bool SupportsDynamicReloading() override;
+
+	/** FTickableGameObject implementation */
+	bool IsTickable() const override { return true; }
+	bool IsTickableInEditor() const override { return true; }
+	bool IsTickableWhenPaused() const override { return true; }
+	TStatId GetStatId() const override
+	{
+		return TStatId();
+	}
+	void Tick(float DeltaTime) override;
 
 protected:
 

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Public/UserInfo/UserInfo.h
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Public/UserInfo/UserInfo.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include "Object.h"
+
+#include "eos_sdk.h"
+#include "eos_userinfo.h"
+
+#include "UserInfo.generated.h"
+
+DECLARE_DYNAMIC_MULTICAST_DELEGATE_OneParam(FOnUserInfoRetreived, const FAccountId&, AccountId);
+
+UCLASS()
+class UEOS_API UEOSUserInfo : public UObject
+{
+	GENERATED_BODY()
+
+public:
+
+	UEOSUserInfo();
+	void Init();
+	/**
+	 * Begins an async process to get this user's display name.  Broadcasts either OnUserInfoRetreived or OnUserInfoError
+	 * when the request has completed.
+	 */
+	void QueryNameByAccountId(const FAccountId& AccountId);
+	/**
+	 * Returns an empty string if the given AccountId has not been queried.
+	 */
+	FString GetDisplayName(const FAccountId& AccountId);
+
+	FOnUserInfoRetreived OnUserInfoRetreived;
+	FOnUserInfoRetreived OnUserInfoError;
+
+private:
+	static void QueryUserInfoCallback(const EOS_UserInfo_QueryUserInfoCallbackInfo* Data);
+
+	/** Handle for the UserInfo interface */
+	EOS_HUserInfo UserInfoHandle;
+};


### PR DESCRIPTION
Friends and UserInfo both only implement part of the EOS SDK.  These commits allow you to query your friends list and get the status and display name of each friend.  Friend invitation handling and querying AccountIds by display name are currently unimplemented, though we do plan on adding those in the near future.

InitEOS, ShutdownEOS, and UpdateEOS have been moved from protected to public so that they could be called from code as well as blueprints.

By making UEOSModule inherit from FTickableGameObject, the module as a whole no longer needs to be ticked manually.

I have not modified the blueprints at all, nor have I added any to demo working with the Friends and UserInfo interfaces.