### PR TITLE
Update AccountID from SDK, Add TokenCopy Option, Fix ACCOUNTID_MAX

### DIFF
--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Authentication/Authentication.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Authentication/Authentication.cpp
@@ -102,7 +102,10 @@ bool UEOSAuthentication::GetAuthorised()
 
 bool UEOSAuthentication::GetAuthTokenCopy( EOS_Auth_Token** OutToken )
 {
-	EOS_EResult Result = EOS_Auth_CopyUserAuthToken( AuthHandle, UEOSManager::GetAuthentication()->AccountId, OutToken );
+	EOS_Auth_CopyUserAuthTokenOptions TokenOpt;
+	TokenOpt.ApiVersion = EOS_AUTH_COPYUSERAUTHTOKEN_API_LATEST;
+
+	EOS_EResult Result = EOS_Auth_CopyUserAuthToken( AuthHandle, &TokenOpt, UEOSManager::GetAuthentication()->AccountId, OutToken );
 	return Result == EOS_EResult::EOS_Success;
 }
 
@@ -111,11 +114,11 @@ void UEOSAuthentication::ReleaseAuthToken( EOS_Auth_Token* Token )
 	EOS_Auth_Token_Release( Token );
 }
 
-FString UEOSAuthentication::AccountIDToString( EOS_AccountId InAccountId )
+FString UEOSAuthentication::AccountIDToString( EOS_EpicAccountId InAccountId )
 {
-	static char TempBuffer[EOS_ACCOUNTID_MAX_LENGTH];
+	static char TempBuffer[EOS_EPICACCOUNTID_MAX_LENGTH];
 	int32_t TempBufferSize = sizeof( TempBuffer );
-	EOS_AccountId_ToString( InAccountId, TempBuffer, &TempBufferSize );
+	EOS_EpicAccountId_ToString( InAccountId, TempBuffer, &TempBufferSize );
 	FString returnValue( TempBuffer );
 	return returnValue;
 }
@@ -220,20 +223,20 @@ void UEOSAuthentication::PrintAuthToken( EOS_Auth_Token* InAuthToken )
 
 FString FAccountId::ToString() const
 {
-	static char TempBuffer[EOS_ACCOUNTID_MAX_LENGTH];
+	static char TempBuffer[EOS_EPICACCOUNTID_MAX_LENGTH];
 	int32_t TempBufferSize = sizeof( TempBuffer );
-	EOS_AccountId_ToString( AccountId, TempBuffer, &TempBufferSize );
+	EOS_EpicAccountId_ToString( AccountId, TempBuffer, &TempBufferSize );
 	FString returnValue( TempBuffer );
 	return returnValue;
 }
 
 FAccountId FAccountId::FromString(const FString& AccountId)
 {
-	EOS_AccountId Account = EOS_AccountId_FromString(TCHAR_TO_ANSI(*AccountId));
+	EOS_EpicAccountId Account = EOS_EpicAccountId_FromString(TCHAR_TO_ANSI(*AccountId));
 	return FAccountId(Account);
 }
 
 FAccountId::operator bool() const
 {
-	return ( EOS_AccountId_IsValid( AccountId ) == EOS_TRUE ) ? true : false;
+	return ( EOS_EpicAccountId_IsValid( AccountId ) == EOS_TRUE ) ? true : false;
 }

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Friends/Friends.cpp
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Private/Friends/Friends.cpp
@@ -55,7 +55,7 @@ FAccountId UEOSFriends::GetAccountId( int Index )
 	Options.ApiVersion = EOS_FRIENDS_GETFRIENDATINDEX_API_LATEST;
 	Options.LocalUserId = UEOSManager::GetEOSManager()->GetAuthentication()->GetAccountId();
 	Options.Index = Index;
-	EOS_AccountId AccountId = EOS_Friends_GetFriendAtIndex( FriendsHandle, &Options );
+	EOS_EpicAccountId AccountId = EOS_Friends_GetFriendAtIndex( FriendsHandle, &Options );
 	return AccountId;
 }
 

--- a/EOSBasic/Plugins/UEOS/Source/UEOS/Public/Authentication/Authentication.h
+++ b/EOSBasic/Plugins/UEOS/Source/UEOS/Public/Authentication/Authentication.h
@@ -8,6 +8,7 @@
 // EOS Includes
 #include "eos_sdk.h"
 #include "eos_auth.h"
+#include "eos_version.h"
 
 #include "Authentication.generated.h"
 
@@ -41,7 +42,7 @@ struct UEOS_API FAccountId
 	/**
 	* Construct wrapper from account id.
 	*/
-	FAccountId( EOS_AccountId InAccountId )
+	FAccountId( EOS_EpicAccountId InAccountId )
 		: AccountId( InAccountId )
 	{
 	};
@@ -70,7 +71,7 @@ struct UEOS_API FAccountId
 	/**
 	* Easy conversion to EOS account ID.
 	*/
-	operator EOS_AccountId() const
+	operator EOS_EpicAccountId() const
 	{
 		return AccountId;
 	}
@@ -89,7 +90,7 @@ struct UEOS_API FAccountId
 	static FAccountId		FromString( const FString& AccountId );
 
 	/** The EOS SDK matching Account Id. */
-	EOS_AccountId			AccountId;
+	EOS_EpicAccountId			AccountId;
 };
 
 UCLASS()
@@ -154,7 +155,7 @@ public:
 	* @param InAccountId - Account id to convert
 	* @return FString representing the account ID.
 	*/
-	static FString					AccountIDToString( EOS_AccountId InAccountId );
+	static FString					AccountIDToString( EOS_EpicAccountId InAccountId );
 
 	/**
 	* Fires when a User Has Logged In.


### PR DESCRIPTION
Changes AccountID to use new EpicAccountID naming, adds Option struct for EOS_Auth_CopyUserAuthToken, Update to EOS_EPICACCOUNTID_MAX_LENGTH