### PR TITLE
Fix Store interface function missing

### DIFF
--- a/EOSBasic/Plugins/OnlineSubsystemEOS/Source/OnlineSubsystemEOS/Private/OnlineSubsystemEOS.cpp
+++ b/EOSBasic/Plugins/OnlineSubsystemEOS/Source/OnlineSubsystemEOS/Private/OnlineSubsystemEOS.cpp
@@ -69,6 +69,11 @@ IOnlineEntitlementsPtr FOnlineSubsystemEOS::GetEntitlementsInterface() const
 	return nullptr;
 }
 
+IOnlineStorePtr FOnlineSubsystemEOS::GetStoreInterface() const
+{
+	return nullptr;
+}
+
 IOnlineStoreV2Ptr FOnlineSubsystemEOS::GetStoreV2Interface() const
 {
 	return nullptr; 

--- a/EOSBasic/Plugins/OnlineSubsystemEOS/Source/OnlineSubsystemEOS/Public/OnlineSubsystemEOS.h
+++ b/EOSBasic/Plugins/OnlineSubsystemEOS/Source/OnlineSubsystemEOS/Public/OnlineSubsystemEOS.h
@@ -47,6 +47,7 @@ public:
 	virtual IOnlineIdentityPtr			GetIdentityInterface() const override;
 	virtual IOnlineTitleFilePtr			GetTitleFileInterface() const override;
 	virtual IOnlineEntitlementsPtr		GetEntitlementsInterface() const override;
+	virtual IOnlineStorePtr				GetStoreInterface() const override;
 	virtual IOnlineStoreV2Ptr			GetStoreV2Interface() const override;
 	virtual IOnlinePurchasePtr			GetPurchaseInterface() const override;
 	virtual IOnlineEventsPtr			GetEventsInterface() const override;


### PR DESCRIPTION
I was unable to build the plugin in my 4.24 project without adding this function to the Subsystem. I built the Plugin project with 4.25 to ensure it's compatible as well. 